### PR TITLE
Use local dask executors, and expose the dashboard to 8086

### DIFF
--- a/endpoint/index.html
+++ b/endpoint/index.html
@@ -1,1 +1,0 @@
-alive and kicking

--- a/flows.py
+++ b/flows.py
@@ -2,25 +2,52 @@ import prefect
 from prefect import Flow, task
 from prefect.schedules import IntervalSchedule
 from datetime import timedelta, datetime
+from prefect.engine.executors import DaskExecutor
+from prefect.environments.execution import RemoteEnvironment
 
-import time
+import random
+from time import sleep
 
 schedule = IntervalSchedule(
-    start_date=datetime.utcnow() + timedelta(seconds=1),
-    interval=timedelta(minutes=5),
+    start_date=datetime.utcnow() + timedelta(seconds=10),
+    interval=timedelta(minutes=60),
 )
 
 @task
-def run():
+def inc(x):
     logger = prefect.context.get("logger")
-    results = []
-    for x in range(3):
-        results.append(str(x + 1))
-        logger.info("Hello Anaconda Enterprise! run {}".format(x + 1))
-        time.sleep(3)
-    return results
+    logger.info(f"Task started: {datetime.now().strftime('%H:%M:%S.%f')}")
+    sleep(random.uniform(0.5,1.5))
+    return x + 1
+
+
+@task
+def dec(x):
+    logger = prefect.context.get("logger")
+    logger.info(f"Task started: {datetime.now().strftime('%H:%M:%S.%f')}")
+    sleep(random.uniform(0.5,1.5))
+    return x - 1
+
+
+@task
+def add(x, y):
+    logger = prefect.context.get("logger")
+    logger.info(f"Task started: {datetime.now().strftime('%H:%M:%S.%f')}")
+    sleep(random.uniform(0.5,1.5))
+    return x + y
+
+
+@task(name="sum")
+def list_sum(arr):
+    logger = prefect.context.get("logger")
+    logger.info(f"Task started: {datetime.now().strftime('%H:%M:%S.%f')}")
+    return sum(arr)
+
 
 with Flow("Hello Anaconda Enterprise", schedule=schedule) as flow:
-    results = run()
+    incs = inc.map(x=range(100))
+    decs = dec.map(x=range(100))
+    adds = add.map(x=incs, y=decs)
+    total = list_sum(adds)
 
 flow.register(project_name="Hello Anaconda Enterprise")

--- a/prefect_run.sh
+++ b/prefect_run.sh
@@ -1,7 +1,30 @@
+#!/bin/bash
+
 trap 'kill $(jobs -p)' EXIT
-prefect_user_token=$(cat /var/run/secrets/user_credentials/prefectuser)
-prefect_runner_token=$(cat /var/run/secrets/user_credentials/prefectrunner)
-python -m http.server 8086 --directory endpoint &
+
+UC=/var/run/secrets/user_credentials
+prefect_user_token=$(cat $UC/prefectuser)
+prefect_runner_token=$(cat $UC/prefectrunner)
+
+# Start local Dask cluster
+CG=/sys/fs/cgroup
+quota=$(cat $CG/cpu/cpu.cfs_quota_us)
+period=$(cat $CG/cpu/cpu.cfs_period_us)
+membytes=$(cat $CG/memory/memory.stat | sed -nE 's@^hierarchical_memory_limit *@@p')
+nproc=$(( 2 * $quota / $period ))
+memmb=$(( $membytes / 1024 / 1024 / $nproc ))
+echo "Starting dask scheduler with $nproc workers, ${memmb}MB RAM per worker"
+dask-scheduler --dashboard-address :8086 &
+dask-worker localhost:8786 --nprocs $nproc --memory-limit ${memmb}MB --nthreads 1 &
+
+# Tell Prefect to use local Dask cluster
+export PREFECT__ENGINE__EXECUTOR__DEFAULT_CLASS=prefect.engine.executors.DaskExecutor
+export PREFECT__ENGINE__EXECUTOR__DASK__ADDRESS='tcp://127.0.0.1:8786'
+
+# Build flows
 prefect auth login -t $prefect_user_token
 python flows.py
+
+# Start prefect agent
 prefect agent start -t $prefect_runner_token
+


### PR DESCRIPTION
Thanks to @strojank for the collaboration here.

This makes the AE5 prefect deployment use a small Dask cluster to process flows. The container is queried for the number of cores and the amount of memory, and the number of Dask workers and their memory limit is adjusted accordingly. Therefore, if you feel you need more workers or you need to give them more memory, the resource profile should be modified.